### PR TITLE
Fix: Button 터치 영역 확장

### DIFF
--- a/Tikkeul/Presentation/Shared/Components/BottomButton.swift
+++ b/Tikkeul/Presentation/Shared/Components/BottomButton.swift
@@ -20,11 +20,11 @@ struct BottomButton: View {
         } label: {
             Text(title)
                 .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 60)
+                .background(backgroundColor)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: 60)
-        .background(backgroundColor)
-        .clipShape(RoundedRectangle(cornerRadius: 10))
         .padding(.bottom, 10)
     }
 }


### PR DESCRIPTION
### 🔗 이슈 번호
#40 

### 📝 작업 내용
- Bottom Button 터치 영역 확장

### 🚀 트러블 슈팅
- Button의 경우 label에 구현된 Component에 터치 영역을 가지고 있으므로 주의해야 한다.